### PR TITLE
Replace Lanyrd link with Meet-a-bit link

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,5 @@ clicky_site_ids.push(66617529);
 </script>
 <noscript><p><img alt="Clicky" width="1" height="1" src="//in.getclicky.com/66617529ns.gif" /></p></noscript>
 
-<script src="http://cdn.lanyrd.net/badges/person-v1.min.js"></script>
-
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 Never miss a meetup - <a href="http://helsinkijs.us5.list-manage.com/subscribe?u=86fbe9035bf092a72f556cda8&id=f3eaca38d9">subscribe to our mailing list</a>! Hate email? Try these:
 
 
-<a href="http://lanyrd.com/profile/helsinkijs/" class="lanyrd-topbar lanyrd-type-involved" rel="me"><img class="logo" src="images/lanyrd.png"/></a>
+<a href="https://meetabit.com/communities/2" rel="me">HelsinkiJS on Meet-a-bit</a>
 
 <a href="http://twitter.com/helsinkijs" rel="me"><img class="logo"  src="images/twitter.jpg"/></a>
 


### PR DESCRIPTION
The Lanyrd profile is quite out of date and presumably the focus will be in Meet-a-bit anyway, so it might make sense to promote that page instead.
